### PR TITLE
Fix data processing error and universe selection time

### DIFF
--- a/DataProcessing/DataProcessing.csproj
+++ b/DataProcessing/DataProcessing.csproj
@@ -21,4 +21,10 @@
       </None>
     </ItemGroup>
 
+    <ItemGroup>
+      <None Update="config.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+    </ItemGroup>
+
 </Project>

--- a/DataProcessing/Program.cs
+++ b/DataProcessing/Program.cs
@@ -38,7 +38,7 @@ namespace QuantConnect.DataProcessing
             var sourceDirectory = new DirectoryInfo(Config.Get("raw-folder", "/raw"));
             var destinationDirectory = Directory.CreateDirectory(Config.Get("temp-output-directory", "/temp-output-directory"));
             var processedDataDirectory = new DirectoryInfo(Config.Get("processed-data-directory", Globals.DataFolder));
-            var processingDateValue = Config.Get("processing-date-value", Environment.GetEnvironmentVariable("QC_DATAFLEET_DEPLOYMENT_DATE"));
+            var processingDateValue = Config.Get("processing-date", Environment.GetEnvironmentVariable("QC_DATAFLEET_DEPLOYMENT_DATE"));
             
             SmartInsiderConverter instance = null;
             try
@@ -57,7 +57,7 @@ namespace QuantConnect.DataProcessing
             try
             {
                 // Run the data downloader/converter.
-                if (processingDateValue == string.Empty)
+                if (processingDateValue == "all")
                 {
                     instance.Convert();
                 }

--- a/DataProcessing/Program.cs
+++ b/DataProcessing/Program.cs
@@ -38,9 +38,8 @@ namespace QuantConnect.DataProcessing
             var sourceDirectory = new DirectoryInfo(Config.Get("raw-folder", "/raw"));
             var destinationDirectory = Directory.CreateDirectory(Config.Get("temp-output-directory", "/temp-output-directory"));
             var processedDataDirectory = new DirectoryInfo(Config.Get("processed-data-directory", Globals.DataFolder));
-            var processingDateValue = Environment.GetEnvironmentVariable("QC_DATAFLEET_DEPLOYMENT_DATE");
-            var processingDate = Parse.DateTimeExact(processingDateValue, "yyyyMMdd");
-
+            var processingDateValue = Config.Get("processing-date-value", Environment.GetEnvironmentVariable("QC_DATAFLEET_DEPLOYMENT_DATE"));
+            
             SmartInsiderConverter instance = null;
             try
             {
@@ -58,11 +57,19 @@ namespace QuantConnect.DataProcessing
             try
             {
                 // Run the data downloader/converter.
-                var success = instance.Convert(processingDate);
-                if (!success)
+                if (processingDateValue == string.Empty)
                 {
-                    Log.Error($"QuantConnect.DataProcessing.Program.Main(): Failed to process Smart Insider data");
-                    Environment.Exit(1);
+                    instance.Convert();
+                }
+                else
+                {
+                    var success = instance.Convert(Parse.DateTimeExact(processingDateValue, "yyyyMMdd"));
+                
+                    if (!success)
+                    {
+                        Log.Error($"QuantConnect.DataProcessing.Program.Main(): Failed to process Smart Insider data");
+                        Environment.Exit(1);
+                    }
                 }
             }
             catch (Exception err)

--- a/DataProcessing/Program.cs
+++ b/DataProcessing/Program.cs
@@ -57,19 +57,26 @@ namespace QuantConnect.DataProcessing
             try
             {
                 // Run the data downloader/converter.
-                if (processingDateValue == "all")
+                switch (processingDateValue)
                 {
-                    instance.Convert();
-                }
-                else
-                {
-                    var success = instance.Convert(Parse.DateTimeExact(processingDateValue, "yyyyMMdd"));
+                    case "all":
+                        instance.Convert();
+                        break;
+                    
+                    case "universe":
+                        instance.ConvertUniverse();
+                        break;
+
+                    default:
+                        var success = instance.Convert(Parse.DateTimeExact(processingDateValue, "yyyyMMdd"));
                 
-                    if (!success)
-                    {
-                        Log.Error($"QuantConnect.DataProcessing.Program.Main(): Failed to process Smart Insider data");
-                        Environment.Exit(1);
-                    }
+                        if (!success)
+                        {
+                            Log.Error($"QuantConnect.DataProcessing.Program.Main(): Failed to process Smart Insider data");
+                            Environment.Exit(1);
+                        }
+                        
+                        break;
                 }
             }
             catch (Exception err)

--- a/DataProcessing/SmartInsiderConverter.cs
+++ b/DataProcessing/SmartInsiderConverter.cs
@@ -384,7 +384,6 @@ namespace QuantConnect.DataProcessing
             var buybackPercentage = data.BuybackPercentage;
             var volumePercentage = data.VolumePercentage;
             var dataInstance = $@"{cap},{price},{price},{amount},{usdValue},{buybackPercentage},{volumePercentage}";
-            Console.WriteLine(dataInstance);
 
             Dictionary<string, string> dataDict;
             if (!_transactionUniverse.TryGetValue(date, out dataDict))

--- a/DataProcessing/SmartInsiderConverter.cs
+++ b/DataProcessing/SmartInsiderConverter.cs
@@ -218,7 +218,7 @@ namespace QuantConnect.DataProcessing
                 }
 
                 var sid = SecurityIdentifier.GenerateEquity(mapFile.FirstDate, newTicker, Market.USA);
-                ProcessUniverse(sid.ToString(), dataInstance);
+                ProcessUniverse($"{sid},{newTicker}", dataInstance);
 
                 List<T> symbolLines;
                 if (!lines.TryGetValue(newTicker, out symbolLines))

--- a/DataProcessing/SmartInsiderConverter.cs
+++ b/DataProcessing/SmartInsiderConverter.cs
@@ -322,7 +322,7 @@ namespace QuantConnect.DataProcessing
         /// <param name="data">Base class data</param>
         private void ProcessUniverse(string tickerInfo, SmartInsiderIntention data)
         {
-            var date = $"{data.AnnouncementDate:yyyyMMdd}";
+            var date = $"{data.TimeProcessedUtc:yyyyMMdd}";
             var cap = data.USDMarketCap;
             var minPrice = data.MinimumPrice;
             var maxPrice = data.MaximumPrice;
@@ -361,9 +361,9 @@ namespace QuantConnect.DataProcessing
                     newMaxPrice = newMax > maxPrice ? newMax : maxPrice;
                 }
 
-                var newAmount = (string.IsNullOrEmpty(oldValue[0]) ? 0L : long.Parse(oldValue[0], NumberStyles.Any, CultureInfo.InvariantCulture)) + amount;
-                var newAmountValue = (string.IsNullOrEmpty(oldValue[1]) ? 0L : long.Parse(oldValue[1], NumberStyles.Any, CultureInfo.InvariantCulture)) + amountValue;
-                var newPercent = (string.IsNullOrEmpty(oldValue[2]) ? 0m : decimal.Parse(oldValue[2], NumberStyles.Any, CultureInfo.InvariantCulture)) + percent;
+                var newAmount = (string.IsNullOrEmpty(oldValue[0]) ? 0 : long.Parse(oldValue[0], NumberStyles.Any, CultureInfo.InvariantCulture)) + amount;
+                var newAmountValue = (string.IsNullOrEmpty(oldValue[1]) ? 0 : long.Parse(oldValue[1], NumberStyles.Any, CultureInfo.InvariantCulture)) + amountValue;
+                var newPercent = (string.IsNullOrEmpty(oldValue[2]) ? 0 : decimal.Parse(oldValue[2], NumberStyles.Any, CultureInfo.InvariantCulture)) + percent;
 
                 dataDict[tickerInfo] = $"{cap},{newMinPrice},{newMaxPrice},{newAmount},{newAmountValue},{newPercent}";
             }
@@ -376,7 +376,7 @@ namespace QuantConnect.DataProcessing
         /// <param name="data">Base class data</param>
         private void ProcessUniverse(string tickerInfo, SmartInsiderTransaction data)
         {
-            var date = $"{data.BuybackDate:yyyyMMdd}";
+            var date = $"{data.TimeProcessedUtc:yyyyMMdd}";
             var cap = data.USDMarketCap;
             var price = data.ExecutionPrice;
             var amount = data.Amount;
@@ -384,6 +384,7 @@ namespace QuantConnect.DataProcessing
             var buybackPercentage = data.BuybackPercentage;
             var volumePercentage = data.VolumePercentage;
             var dataInstance = $@"{cap},{price},{price},{amount},{usdValue},{buybackPercentage},{volumePercentage}";
+            Console.WriteLine(dataInstance);
 
             Dictionary<string, string> dataDict;
             if (!_transactionUniverse.TryGetValue(date, out dataDict))
@@ -415,10 +416,10 @@ namespace QuantConnect.DataProcessing
                     newMaxPrice = newMax > price ? newMax : price;
                 }
 
-                var newAmount = (string.IsNullOrEmpty(oldValue[0]) ? 0 : decimal.Parse(oldValue[0], NumberStyles.Any, CultureInfo.InvariantCulture)) + amount;
-                var newValue = (string.IsNullOrEmpty(oldValue[3]) ? 0 : decimal.Parse(oldValue[3], NumberStyles.Any, CultureInfo.InvariantCulture)) + usdValue;
-                var newBuybackPercentage = (string.IsNullOrEmpty(oldValue[4]) ? 0 : decimal.Parse(oldValue[4], NumberStyles.Any, CultureInfo.InvariantCulture)) + buybackPercentage;
-                var newVolumePercentage = (string.IsNullOrEmpty(oldValue[5]) ? 0 : decimal.Parse(oldValue[5], NumberStyles.Any, CultureInfo.InvariantCulture)) + volumePercentage;
+                var newAmount = (string.IsNullOrEmpty(oldValue[3]) ? 0 : decimal.Parse(oldValue[3], NumberStyles.Any, CultureInfo.InvariantCulture)) + amount;
+                var newValue = (string.IsNullOrEmpty(oldValue[4]) ? 0 : decimal.Parse(oldValue[4], NumberStyles.Any, CultureInfo.InvariantCulture)) + usdValue;
+                var newBuybackPercentage = (string.IsNullOrEmpty(oldValue[5]) ? 0 : decimal.Parse(oldValue[5], NumberStyles.Any, CultureInfo.InvariantCulture)) + buybackPercentage;
+                var newVolumePercentage = (string.IsNullOrEmpty(oldValue[6]) ? 0 : decimal.Parse(oldValue[6], NumberStyles.Any, CultureInfo.InvariantCulture)) + volumePercentage;
 
                 dataDict[tickerInfo] = $"{cap},{newMinPrice},{newMaxPrice},{newAmount},{newValue},{newBuybackPercentage},{newVolumePercentage}";
             }

--- a/DataProcessing/config.json
+++ b/DataProcessing/config.json
@@ -1,3 +1,4 @@
 {
-    "data-folder": "../../Lean/Data"
+    "data-folder": "../../LeanCLI/data",
+    "processing-date": "all"
 }

--- a/DataProcessing/config.json
+++ b/DataProcessing/config.json
@@ -1,0 +1,3 @@
+{
+    "data-folder": "../../LeanCLI/data"
+}

--- a/DataProcessing/config.json
+++ b/DataProcessing/config.json
@@ -1,4 +1,3 @@
 {
-    "data-folder": "../../Lean/Data",
-    "processing-date-value": ""
+    "data-folder": "../../Lean/Data"
 }

--- a/DataProcessing/config.json
+++ b/DataProcessing/config.json
@@ -1,3 +1,4 @@
 {
-    "data-folder": "../../LeanCLI/data"
+    "data-folder": "../../Lean/Data",
+    "processing-date-value": ""
 }

--- a/QuantConnect.DataSource.csproj
+++ b/QuantConnect.DataSource.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="QuantConnect.Common" Version="2.5.*" />
-    <PackageReference Include="protobuf-net" Version="3.0.29" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
@@ -28,6 +27,7 @@
     <Compile Remove="SmartInsiderIntentionUniverseSelectionAlgorithm.cs" />
     <Compile Remove="SmartInsiderTransactionAlgorithm.cs" />
     <Compile Remove="SmartInsiderTransactionUniverseSelectionAlgorithm.cs" />
+    <Compile Remove="SmartInsiderTransactionUniverseTestAlgorithm.cs" />
     <None Remove="SmartInsiderDataAlgorithm.py" />
     <None Remove="SmartInsiderEventBenchmarkAlgorithm.py" />
     <None Remove="SmartInsiderIntentionUniverseSelectionAlgorithm.py" />

--- a/SmartInsiderIntentionUniverse.cs
+++ b/SmartInsiderIntentionUniverse.cs
@@ -102,7 +102,7 @@ namespace QuantConnect.DataSource
             return new SmartInsiderIntentionUniverse
             {
                 Symbol = new Symbol(SecurityIdentifier.Parse(csv[0]), csv[1]),
-                Time = date - _period,
+                Time = date,
                 Value = Convert.ToDecimal(amountValue),
 
                 MinimumPrice = csv[3].IfNotNullOrEmpty<decimal?>(x => decimal.Parse(x, NumberStyles.Any, CultureInfo.InvariantCulture)),

--- a/SmartInsiderIntentionUniverse.cs
+++ b/SmartInsiderIntentionUniverse.cs
@@ -27,7 +27,7 @@ namespace QuantConnect.DataSource
     /// </summary>
     public class SmartInsiderIntentionUniverse : BaseData
     {
-        private TimeSpan _period = TimeSpan.FromDays(1);
+        private static readonly TimeSpan _period = TimeSpan.FromDays(1);
         
         /// <summary>
         /// Number of shares to be or authorised to be traded

--- a/SmartInsiderTransactionUniverse.cs
+++ b/SmartInsiderTransactionUniverse.cs
@@ -107,7 +107,7 @@ namespace QuantConnect.DataSource
             return new SmartInsiderTransactionUniverse
             {
                 Symbol = new Symbol(SecurityIdentifier.Parse(csv[0]), csv[1]),
-                Time = date - _period,
+                Time = date,
                 Value = Convert.ToDecimal(usdValue),
 
                 USDMarketCap = csv[2].IfNotNullOrEmpty<decimal?>(x => decimal.Parse(x, NumberStyles.Any, CultureInfo.InvariantCulture)),

--- a/SmartInsiderTransactionUniverse.cs
+++ b/SmartInsiderTransactionUniverse.cs
@@ -27,7 +27,7 @@ namespace QuantConnect.DataSource
     /// </summary>
     public class SmartInsiderTransactionUniverse : BaseData
     {
-        private TimeSpan _period = TimeSpan.FromDays(1);
+        private static readonly TimeSpan _period = TimeSpan.FromDays(1);
         
         /// <summary>
         /// Number of shares traded

--- a/SmartInsiderTransactionUniverseTestAlgorithm.cs
+++ b/SmartInsiderTransactionUniverseTestAlgorithm.cs
@@ -1,0 +1,84 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuantConnect.Data;
+using QuantConnect.Data.UniverseSelection;
+using QuantConnect.DataSource;
+using QuantConnect.Securities;
+
+namespace QuantConnect.Algorithm.CSharp
+{
+    public class SmartInsiderTransactionUniverseTestAlgorithm : QCAlgorithm
+    {
+        private readonly Symbol _symbol = QuantConnect.Symbol.Create("AAPL", SecurityType.Equity, Market.USA);
+        private Security _smartInsiderTransaction;
+        private SmartInsiderTransactionUniverse _datum;
+        private List<SmartInsiderTransaction> _collection = new();
+        private DateTime _day;
+
+        public override void Initialize()
+        {
+            // Data ADDED via universe selection is added with Daily resolution.
+            UniverseSettings.Resolution = Resolution.Daily;
+
+	        SetStartDate(2021, 10, 29);
+	        SetEndDate(2021, 11, 1);
+            SetCash(100000);
+
+            // Add data for a single security
+            _smartInsiderTransaction = AddData<SmartInsiderTransaction>(_symbol);
+
+            // add a custom universe data source
+            AddUniverse<SmartInsiderTransactionUniverse>("SmartInsiderTransactionUniverse", Resolution.Daily, UniverseSelectionMethod);
+        }
+
+        private IEnumerable<Symbol> UniverseSelectionMethod(IEnumerable<SmartInsiderTransactionUniverse> data)
+        {
+            _datum = data.FirstOrDefault(datum => datum.Symbol.Value == _symbol.Value);
+
+            if (_datum != null)
+            {
+                Debug(_datum.ToString());
+                _day = _datum.EndTime;
+            }
+
+            return Universe.Unchanged;
+        }
+
+        public override void OnData(Slice slice)
+        {
+            // Sanity check for Universe Selection. The Value (Followers) should be the same.
+            // and if-condition should not be true
+            var data = slice.Get<SmartInsiderTransaction>().Values;
+
+            if (Time.Day == _day.Day)
+            {
+                _collection.AddRange(data);
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            if (_collection?.First().EndTime.Day == _datum?.EndTime.Day && _collection?.Sum(x => x.Amount) != _datum?.Amount)
+            {
+                var message = $"Data mismatch: Single: ({_collection?.First().EndTime} > {_collection?.Sum(x => x.Amount)}) vs Universe ({_datum?.EndTime} > {_datum?.Amount})";
+                throw new Exception(message: message);
+            }
+        }
+    }
+}

--- a/tests/SmartInsiderIntentionTests.cs
+++ b/tests/SmartInsiderIntentionTests.cs
@@ -15,10 +15,8 @@
 */
 
 using System;
-using ProtoBuf;
 using System.IO;
 using System.Linq;
-using ProtoBuf.Meta;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using QuantConnect.Data;
@@ -38,27 +36,6 @@ namespace QuantConnect.DataLibrary.Tests
             var result = JsonConvert.DeserializeObject(serialized, type);
 
             AssertAreEqual(expected, result);
-        }
-
-        [Test]
-	[Ignore("ProtoBuf not implemented for this data type yet")]
-        public void ProtobufRoundTrip()
-        {
-            var expected = CreateNewInstance();
-            var type = expected.GetType();
-
-            RuntimeTypeModel.Default[typeof(BaseData)].AddSubType(2000, type);
-
-            using (var stream = new MemoryStream())
-            {
-                Serializer.Serialize(stream, expected);
-
-                stream.Position = 0;
-
-                var result = Serializer.Deserialize(type, stream);
-
-                AssertAreEqual(expected, result, filterByCustomAttributes: true);
-            }
         }
 
         [Test]

--- a/tests/SmartInsiderIntentionUniverseTests.cs
+++ b/tests/SmartInsiderIntentionUniverseTests.cs
@@ -15,11 +15,9 @@
 */
 
 using System;
-using ProtoBuf;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using ProtoBuf.Meta;
 using Newtonsoft.Json;
 using NodaTime;
 using NUnit.Framework;

--- a/tests/SmartInsiderTransactionTests.cs
+++ b/tests/SmartInsiderTransactionTests.cs
@@ -15,10 +15,8 @@
 */
 
 using System;
-using ProtoBuf;
 using System.IO;
 using System.Linq;
-using ProtoBuf.Meta;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using QuantConnect.Data;
@@ -38,27 +36,6 @@ namespace QuantConnect.DataLibrary.Tests
             var result = JsonConvert.DeserializeObject(serialized, type);
 
             AssertAreEqual(expected, result);
-        }
-
-        [Test]
-	[Ignore("ProtoBuf not implemented for this data type yet")]
-        public void ProtobufRoundTrip()
-        {
-            var expected = CreateNewInstance();
-            var type = expected.GetType();
-
-            RuntimeTypeModel.Default[typeof(BaseData)].AddSubType(2000, type);
-
-            using (var stream = new MemoryStream())
-            {
-                Serializer.Serialize(stream, expected);
-
-                stream.Position = 0;
-
-                var result = Serializer.Deserialize(type, stream);
-
-                AssertAreEqual(expected, result, filterByCustomAttributes: true);
-            }
         }
 
         [Test]

--- a/tests/SmartInsiderTransactionUniverseTests.cs
+++ b/tests/SmartInsiderTransactionUniverseTests.cs
@@ -15,11 +15,9 @@
 */
 
 using System;
-using ProtoBuf;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using ProtoBuf.Meta;
 using Newtonsoft.Json;
 using NodaTime;
 using NUnit.Framework;

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -10,6 +10,7 @@
     <Compile Include="..\SmartInsiderIntentionUniverseSelectionAlgorithm.cs" Link="SmartInsiderIntentionUniverseSelectionAlgorithm.cs" />
     <Compile Include="..\SmartInsiderTransactionAlgorithm.cs" Link="SmartInsiderTransactionAlgorithm.cs" />
     <Compile Include="..\SmartInsiderTransactionUniverseSelectionAlgorithm.cs" Link="SmartInsiderTransactionUniverseSelectionAlgorithm.cs" />
+    <Compile Include="..\SmartInsiderTransactionUniverseTestAlgorithm.cs" Link="SmartInsiderTransactionUniverseTestAlgorithm.cs" />
     <Content Include="..\SmartInsiderDataAlgorithm.py" Link="SmartInsiderDataAlgorithm.py" />
     <Content Include="..\SmartInsiderEventBenchmarkAlgorithm.py" Link="SmartInsiderEventBenchmarkAlgorithm.py" />
     <Content Include="..\SmartInsiderIntentionUniverseSelectionAlgorithm.py" Link="SmartInsiderIntentionUniverseSelectionAlgorithm.py" />
@@ -17,7 +18,6 @@
     <Content Include="..\SmartInsiderTransactionUniverseSelectionAlgorithm.py" Link="SmartInsiderTransactionUniverseSelectionAlgorithm.py" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="protobuf-net" Version="3.0.29" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
- Fix wrong date of event of `SmartInsiderIntentionUniverse` and `SmartInsiderTransactionUniverse`
- Fix missing ticker column of `SmartInsiderIntentionUniverse` and `SmartInsiderTransactionUniverse`
- Fix wrong mapped column during data aggregation in `ProcessUniverseFile<SmartInsiderTransaction>` in data processor
- Fix look-ahead bias of `SmartInsiderIntentionUniverse` and `SmartInsiderTransactionUniverse`, from the `Date` attribute
- Added sanity test algorithm for testing the above 4 changes' effects (`SmartInsiderTransactionUniverseTestAlgorithm.cs`)
- Add option to reprocess all raw data, and universe files only