### PR TITLE
Correct the wrong mapped intention universe data

### DIFF
--- a/DataProcessing/SmartInsiderConverter.cs
+++ b/DataProcessing/SmartInsiderConverter.cs
@@ -397,22 +397,22 @@ namespace QuantConnect.DataProcessing
                 var oldValue = dataDict[tickerInfo].Split(",");
 
                 var newMinPrice = minPrice;
-                if (!string.IsNullOrEmpty(oldValue[3]))
+                if (!string.IsNullOrEmpty(oldValue[1]))
                 {
-                    var newMin = decimal.Parse(oldValue[3], NumberStyles.Any, CultureInfo.InvariantCulture);
+                    var newMin = decimal.Parse(oldValue[2], NumberStyles.Any, CultureInfo.InvariantCulture);
                     newMinPrice = newMin < minPrice ? newMin : minPrice;
                 }
 
                 var newMaxPrice = maxPrice;
-                if (!string.IsNullOrEmpty(oldValue[4]))
+                if (!string.IsNullOrEmpty(oldValue[2]))
                 {
-                    var newMax = decimal.Parse(oldValue[4], NumberStyles.Any, CultureInfo.InvariantCulture);
+                    var newMax = decimal.Parse(oldValue[2], NumberStyles.Any, CultureInfo.InvariantCulture);
                     newMaxPrice = newMax > maxPrice ? newMax : maxPrice;
                 }
 
-                var newAmount = (string.IsNullOrEmpty(oldValue[0]) ? 0 : long.Parse(oldValue[0], NumberStyles.Any, CultureInfo.InvariantCulture)) + amount;
-                var newAmountValue = (string.IsNullOrEmpty(oldValue[1]) ? 0 : long.Parse(oldValue[1], NumberStyles.Any, CultureInfo.InvariantCulture)) + amountValue;
-                var newPercent = (string.IsNullOrEmpty(oldValue[2]) ? 0 : decimal.Parse(oldValue[2], NumberStyles.Any, CultureInfo.InvariantCulture)) + percent;
+                var newAmount = (string.IsNullOrEmpty(oldValue[3]) ? 0 : long.Parse(oldValue[3], NumberStyles.Any, CultureInfo.InvariantCulture)) + amount;
+                var newAmountValue = (string.IsNullOrEmpty(oldValue[4]) ? 0 : long.Parse(oldValue[4], NumberStyles.Any, CultureInfo.InvariantCulture)) + amountValue;
+                var newPercent = (string.IsNullOrEmpty(oldValue[5]) ? 0 : decimal.Parse(oldValue[5], NumberStyles.Any, CultureInfo.InvariantCulture)) + percent;
 
                 dataDict[tickerInfo] = $"{cap},{newMinPrice},{newMaxPrice},{newAmount},{newAmountValue},{newPercent}";
             }

--- a/DataProcessing/SmartInsiderConverter.cs
+++ b/DataProcessing/SmartInsiderConverter.cs
@@ -36,8 +36,8 @@ namespace QuantConnect.DataProcessing
 
         private readonly MapFileResolver _mapFileResolver;
 
-         private Dictionary<string, Dictionary<string, string>> _intentionUniverse = new();
-        private Dictionary<string, Dictionary<string, string>> _transactionUniverse = new();
+        public Dictionary<string, Dictionary<string, string>> IntentionUniverse = new();
+        public Dictionary<string, Dictionary<string, string>> TransactionUniverse = new();
 
         /// <summary>
         /// Creates an instance of the converter
@@ -57,6 +57,13 @@ namespace QuantConnect.DataProcessing
 
             Directory.CreateDirectory(Path.Combine(_destinationDirectory.FullName, "intentions", "universe"));
             Directory.CreateDirectory(Path.Combine(_destinationDirectory.FullName, "transactions", "universe"));
+        }
+
+        /// <summary>
+        /// Creates an instance of the converter for testing only
+        /// </summary>
+        public SmartInsiderConverter()
+        {
         }
 
         /// <summary>
@@ -105,14 +112,14 @@ namespace QuantConnect.DataProcessing
                 }
             }
 
-            if (_intentionUniverse.Count > 0)
+            if (IntentionUniverse.Count > 0)
             {
-                WriteUniverseFile(intentionsDirectory, _intentionUniverse);
+                WriteUniverseFile(intentionsDirectory, IntentionUniverse);
             }
 
-            if (_transactionUniverse.Count > 0)
+            if (TransactionUniverse.Count > 0)
             {
-                WriteUniverseFile(transactionsDirectory, _transactionUniverse);
+                WriteUniverseFile(transactionsDirectory, TransactionUniverse);
             }
 
             Log.Trace("SmartInsiderConverter.Convert(): Parsed all raw SmartInsider data");
@@ -167,14 +174,14 @@ namespace QuantConnect.DataProcessing
                     Log.Error($"SmartInsiderConverter.Convert(): Raw transactions file does not exist: {rawTransactionsFile.FullName}");
                 }
 
-                if (_intentionUniverse.Count > 0)
+                if (IntentionUniverse.Count > 0)
                 {
-                    WriteUniverseFile(intentionsDirectory, _intentionUniverse);
+                    WriteUniverseFile(intentionsDirectory, IntentionUniverse);
                 }
 
-                if (_transactionUniverse.Count > 0)
+                if (TransactionUniverse.Count > 0)
                 {
-                    WriteUniverseFile(transactionsDirectory, _transactionUniverse);
+                    WriteUniverseFile(transactionsDirectory, TransactionUniverse);
                 }
             }
             catch (Exception e)
@@ -186,24 +193,30 @@ namespace QuantConnect.DataProcessing
             return true;
         }
 
+        /// <summary>
+        /// Convert processed tickers files into universe daily files
+        /// </summary>
         public void ConvertUniverse()
         {
             var intentionsDirectory = new DirectoryInfo(Path.Combine(_destinationDirectory.FullName, "intentions"));
             var transactionsDirectory = new DirectoryInfo(Path.Combine(_destinationDirectory.FullName, "transactions"));
 
             ConvertUniverse<SmartInsiderIntention>("intentions");
-            if (_intentionUniverse.Count > 0)
+            if (IntentionUniverse.Count > 0)
             {
-                WriteUniverseFile(intentionsDirectory, _intentionUniverse);
+                WriteUniverseFile(intentionsDirectory, IntentionUniverse);
             }
 
             ConvertUniverse<SmartInsiderTransaction>("transactions");
-            if (_transactionUniverse.Count > 0)
+            if (TransactionUniverse.Count > 0)
             {
-                WriteUniverseFile(transactionsDirectory, _transactionUniverse);
+                WriteUniverseFile(transactionsDirectory, TransactionUniverse);
             }
         }
 
+        /// <summary>
+        /// Convert processed tickers files of type T into universe daily files of type T
+        /// </summary>
         private void ConvertUniverse<T>(string dataType) where T : SmartInsiderEvent, new()
         {
             foreach (var file in Directory.GetFiles(Path.Combine(_processedDirectory.FullName, dataType), "*.tsv"))
@@ -369,7 +382,7 @@ namespace QuantConnect.DataProcessing
         /// </summary>
         /// <param name="tickerInfo">ticker info string containing security ID string and ticker symbol</param>
         /// <param name="data">Base class data</param>
-        private void ProcessUniverse(string tickerInfo, SmartInsiderIntention data)
+        public void ProcessUniverse(string tickerInfo, SmartInsiderIntention data)
         {
             var date = $"{data.TimeProcessedUtc:yyyyMMdd}";
             var cap = data.USDMarketCap;
@@ -381,10 +394,10 @@ namespace QuantConnect.DataProcessing
             var dataInstance = $@"{cap},{minPrice},{maxPrice},{amount},{amountValue},{percent}";
 
             Dictionary<string, string> dataDict;
-            if (!_intentionUniverse.TryGetValue(date, out dataDict))
+            if (!IntentionUniverse.TryGetValue(date, out dataDict))
             {
                 dataDict = new Dictionary<string, string>();
-                _intentionUniverse[date] = dataDict;
+                IntentionUniverse[date] = dataDict;
             }
 
             if (!dataDict.ContainsKey(tickerInfo))
@@ -423,7 +436,7 @@ namespace QuantConnect.DataProcessing
         /// </summary>
         /// <param name="tickerInfo">ticker info string containing security ID string and ticker symbol</param>
         /// <param name="data">Base class data</param>
-        private void ProcessUniverse(string tickerInfo, SmartInsiderTransaction data)
+        public void ProcessUniverse(string tickerInfo, SmartInsiderTransaction data)
         {
             var date = $"{data.TimeProcessedUtc:yyyyMMdd}";
             var cap = data.USDMarketCap;
@@ -435,10 +448,10 @@ namespace QuantConnect.DataProcessing
             var dataInstance = $@"{cap},{price},{price},{amount},{usdValue},{buybackPercentage},{volumePercentage}";
 
             Dictionary<string, string> dataDict;
-            if (!_transactionUniverse.TryGetValue(date, out dataDict))
+            if (!TransactionUniverse.TryGetValue(date, out dataDict))
             {
                 dataDict = new Dictionary<string, string>();
-                _transactionUniverse[date] = dataDict;
+                TransactionUniverse[date] = dataDict;
             }
 
             if (!dataDict.ContainsKey(tickerInfo))

--- a/DataProcessing/SmartInsiderConverter.cs
+++ b/DataProcessing/SmartInsiderConverter.cs
@@ -36,8 +36,8 @@ namespace QuantConnect.DataProcessing
 
         private readonly MapFileResolver _mapFileResolver;
 
-        public Dictionary<string, Dictionary<string, string>> IntentionUniverse = new();
-        public Dictionary<string, Dictionary<string, string>> TransactionUniverse = new();
+        protected Dictionary<string, Dictionary<string, string>> IntentionUniverse = new();
+        protected Dictionary<string, Dictionary<string, string>> TransactionUniverse = new();
 
         /// <summary>
         /// Creates an instance of the converter
@@ -62,7 +62,7 @@ namespace QuantConnect.DataProcessing
         /// <summary>
         /// Creates an instance of the converter for testing only
         /// </summary>
-        public SmartInsiderConverter()
+        protected SmartInsiderConverter()
         {
         }
 
@@ -357,12 +357,14 @@ namespace QuantConnect.DataProcessing
             return lines;
         }
 
+        ///
+
         /// <summary>
         /// Processes the data to universe
         /// </summary>
         /// <param name="tickerInfo">ticker info string containing security ID string and ticker symbol</param>
         /// <param name="data">Base class data</param>
-        private void ProcessUniverse<T>(string tickerInfo, T data)
+        protected void ProcessUniverse<T>(string tickerInfo, T data)
             where T : SmartInsiderEvent
         {
             if (typeof(T) == typeof(SmartInsiderIntention))
@@ -382,7 +384,7 @@ namespace QuantConnect.DataProcessing
         /// </summary>
         /// <param name="tickerInfo">ticker info string containing security ID string and ticker symbol</param>
         /// <param name="data">Base class data</param>
-        public void ProcessUniverse(string tickerInfo, SmartInsiderIntention data)
+        private void ProcessUniverse(string tickerInfo, SmartInsiderIntention data)
         {
             var date = $"{data.TimeProcessedUtc:yyyyMMdd}";
             var cap = data.USDMarketCap;
@@ -436,7 +438,7 @@ namespace QuantConnect.DataProcessing
         /// </summary>
         /// <param name="tickerInfo">ticker info string containing security ID string and ticker symbol</param>
         /// <param name="data">Base class data</param>
-        public void ProcessUniverse(string tickerInfo, SmartInsiderTransaction data)
+        private void ProcessUniverse(string tickerInfo, SmartInsiderTransaction data)
         {
             var date = $"{data.TimeProcessedUtc:yyyyMMdd}";
             var cap = data.USDMarketCap;

--- a/DataProcessing/TestSmartInsiderConverter.cs
+++ b/DataProcessing/TestSmartInsiderConverter.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using QuantConnect.DataSource;
+
+namespace QuantConnect.DataProcessing
+{
+    public class TestSmartInsiderConverter : SmartInsiderConverter
+    {
+        /// <summary>
+        /// Creates an instance of the converter for testing only
+        /// </summary>
+        public TestSmartInsiderConverter()
+            : base()
+        {
+        }
+
+        /// <summary>
+        /// Get method of IntentionUniverse dictionary
+        /// </summary>
+        /// <return>IntentionUniverse dictionary</return>
+        public Dictionary<string, Dictionary<string, string>> GetIntentionUniverse()
+        {
+            return IntentionUniverse;
+        }
+
+        /// <summary>
+        /// Get method of TransactionUniverse dictionary
+        /// </summary>
+        /// <return>TransactionUniverse dictionary</return>
+        public Dictionary<string, Dictionary<string, string>> GetTransactionUniverse()
+        {
+            return TransactionUniverse;
+        }
+
+        /// <summary>
+        /// Test ProcessUniverse method of base class
+        /// </summary>
+        public void TestProcessUniverse<T>(string tickerInfo, T data)
+            where T : SmartInsiderEvent
+        {
+            base.ProcessUniverse(tickerInfo, data);
+        }
+    }
+}

--- a/DataProcessing/config.json
+++ b/DataProcessing/config.json
@@ -1,4 +1,4 @@
 {
-    "data-folder": "../../LeanCLI/data",
+    "data-folder": "../../Lean/Data",
     "processing-date": "all"
 }

--- a/SmartInsiderIntention.cs
+++ b/SmartInsiderIntention.cs
@@ -14,12 +14,13 @@
 */
 
 using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
+using System.Linq;
 using Newtonsoft.Json;
 using QuantConnect.Data;
-using System.Globalization;
 using QuantConnect.Logging;
-using System.Collections.Generic;
 
 namespace QuantConnect.DataSource
 {
@@ -118,7 +119,7 @@ namespace QuantConnect.DataSource
             ExecutionHolding = ExecutionHolding == SmartInsiderExecutionHolding.Error ? SmartInsiderExecutionHolding.SatisfyStockVesting : ExecutionHolding;
             Amount = string.IsNullOrWhiteSpace(tsv[29]) ? (int?)null : Convert.ToInt32(tsv[29], CultureInfo.InvariantCulture);
             ValueCurrency = string.IsNullOrWhiteSpace(tsv[30]) ? null : tsv[30];
-            AmountValue = string.IsNullOrWhiteSpace(tsv[31]) ? (long?)null : Convert.ToInt64(tsv[31], CultureInfo.InvariantCulture);
+            AmountValue = string.IsNullOrWhiteSpace(tsv[31]) ? (long?)null : Convert.ToInt64(new String(tsv[31].Where(Char.IsDigit).ToArray()), CultureInfo.InvariantCulture);
             Percentage = string.IsNullOrWhiteSpace(tsv[32]) ? (decimal?)null : Convert.ToDecimal(tsv[32], CultureInfo.InvariantCulture);
             AuthorizationStartDate = string.IsNullOrWhiteSpace(tsv[33]) ? (DateTime?)null : DateTime.ParseExact(tsv[33], "yyyyMMdd", CultureInfo.InvariantCulture);
             AuthorizationEndDate = string.IsNullOrWhiteSpace(tsv[34]) ? (DateTime?)null : DateTime.ParseExact(tsv[34], "yyyyMMdd", CultureInfo.InvariantCulture);

--- a/tests/SmartInsiderIntentionUniverseTests.cs
+++ b/tests/SmartInsiderIntentionUniverseTests.cs
@@ -47,15 +47,16 @@ namespace QuantConnect.DataLibrary.Tests
             ExpectedResult = "SID,ticker,,22.5000,26.5000,,250000000,")]
         public string ProcessUniverseTest(string[] tickerData, string date)
         {
-            var instance = new SmartInsiderConverter();
+            var instance = new TestSmartInsiderConverter();
 
             foreach (var line in tickerData)
             {
                 var smartInsiderIntention = new SmartInsiderIntention(line);
-                instance.ProcessUniverse("SID,ticker", smartInsiderIntention);
+                instance.TestProcessUniverse("SID,ticker", smartInsiderIntention);
             }
 
-            var result = instance.IntentionUniverse[date].First();
+            var intentionUniverse = instance.GetIntentionUniverse();
+            var result = intentionUniverse[date].First();
 
             return $"{result.Key},{result.Value}";
         }

--- a/tests/SmartInsiderIntentionUniverseTests.cs
+++ b/tests/SmartInsiderIntentionUniverseTests.cs
@@ -22,6 +22,7 @@ using Newtonsoft.Json;
 using NodaTime;
 using NUnit.Framework;
 using QuantConnect.Data;
+using QuantConnect.DataProcessing;
 using QuantConnect.DataSource;
 using QuantConnect.Data.Market;
 
@@ -30,6 +31,35 @@ namespace QuantConnect.DataLibrary.Tests
     [TestFixture]
     public class SmartInsiderIntentionUniverseTests
     {
+        [TestCase(
+            new string[]{"20200921 07:50:38	BI12705	New Intention	20211212	20200602	US00164V1035		68556	Consumer Discretionary	Media	Media	Entertainment	40301010	AMC Networks Inc					Com A	US	AMCX	20200921				US	Tender Offer	Issuer	Not Reported		USD	250000000					22.5000	26.5000	"}, 
+            "20200921",
+            ExpectedResult = "SID,ticker,,22.5000,26.5000,,250000000,")]
+        [TestCase(
+            new string[]{"20200921 07:50:38	BI12705	New Intention	20211212	20200602	US00164V1035		68556	Consumer Discretionary	Media	Media	Entertainment	40301010	AMC Networks Inc					Com A	US	AMCX	20200921				US	Tender Offer	Issuer	Not Reported		USD	250000000					22.5000	26.5000	",
+                         "20200921 07:50:38	BI12705	New Intention	20211212	20200602	US00164V1035		68556	Consumer Discretionary	Media	Media	Entertainment	40301010	AMC Networks Inc					Com A	US	AMCX	20200921				US	Tender Offer	Issuer	Not Reported		USD	250000000					22.5000	27.5000	"},
+            "20200921",
+            ExpectedResult = "SID,ticker,,22.5000,27.5000,,500000000,")]
+        [TestCase(
+            new string[]{"20200921 07:50:38	BI12705	New Intention	20211212	20200602	US00164V1035		68556	Consumer Discretionary	Media	Media	Entertainment	40301010	AMC Networks Inc					Com A	US	AMCX	20200921				US	Tender Offer	Issuer	Not Reported		USD	250000000					22.5000	26.5000	",
+                         "20200922 07:50:38	BI12705	New Intention	20211212	20200602	US00164V1035		68556	Consumer Discretionary	Media	Media	Entertainment	40301010	AMC Networks Inc					Com A	US	AMCX	20200921				US	Tender Offer	Issuer	Not Reported		USD	250000000					22.5000	26.5000	"},
+            "20200921",
+            ExpectedResult = "SID,ticker,,22.5000,26.5000,,250000000,")]
+        public string ProcessUniverseTest(string[] tickerData, string date)
+        {
+            var instance = new SmartInsiderConverter();
+
+            foreach (var line in tickerData)
+            {
+                var smartInsiderIntention = new SmartInsiderIntention(line);
+                instance.ProcessUniverse("SID,ticker", smartInsiderIntention);
+            }
+
+            var result = instance.IntentionUniverse[date].First();
+
+            return $"{result.Key},{result.Value}";
+        }
+
         [Test]
         public void JsonRoundTrip()
         {

--- a/tests/SmartInsiderTransactionUniverseTests.cs
+++ b/tests/SmartInsiderTransactionUniverseTests.cs
@@ -42,15 +42,16 @@ namespace QuantConnect.DataLibrary.Tests
             ExpectedResult = "SID,ticker,38843345345,154.4500,154.9300,2713215,419380133,0.0108,8.0162")]
         public string ProcessUniverseTest(string[] tickerData, string date)
         {
-            var instance = new SmartInsiderConverter();
+            var instance = new TestSmartInsiderConverter();
 
             foreach (var line in tickerData)
             {
                 var smartInsiderTransaction = new SmartInsiderTransaction(line);
-                instance.ProcessUniverse("SID,ticker", smartInsiderTransaction);
+                instance.TestProcessUniverse("SID,ticker", smartInsiderTransaction);
             }
 
-            var result = instance.TransactionUniverse[date].First();
+            var transactionUniverse = instance.GetTransactionUniverse();
+            var result = transactionUniverse[date].First();
 
             return $"{result.Key},{result.Value}";
         }

--- a/tests/SmartInsiderTransactionUniverseTests.cs
+++ b/tests/SmartInsiderTransactionUniverseTests.cs
@@ -22,6 +22,7 @@ using Newtonsoft.Json;
 using NodaTime;
 using NUnit.Framework;
 using QuantConnect.Data;
+using QuantConnect.DataProcessing;
 using QuantConnect.DataSource;
 using QuantConnect.Data.Market;
 
@@ -30,6 +31,30 @@ namespace QuantConnect.DataLibrary.Tests
     [TestFixture]
     public class SmartInsiderTransactionUniverseTests
     {
+        [TestCase(
+            new string[]{"20220309 11:53:36	BT812996	Transaction	20220309	20191004	US00846U1016	38843345345	27276	Health Care	Health Care	Medical Equipment and Services	Medical Equipment	20102010	Agilent Technologies Inc	20211217	20220222	20220131	20211217	Com	US	A	20220309	20220303 17:02:17		20220303 22:02:17	US	20211231	On Market	Issuer	For Cancellation	USD	154.4500	2038115	232558230	276699052	314786862		0.0081	6.0456	1.350000			"}, 
+            "20220309",
+            ExpectedResult = "SID,ticker,38843345345,154.4500,154.4500,2038115,314786862,0.0081,6.0456")]
+        [TestCase(
+            new string[]{"20220309 11:52:47	BT812992	Transaction	20220309	20191004	US00846U1016	38843345345	27276	Health Care	Health Care	Medical Equipment and Services	Medical Equipment	20102010	Agilent Technologies Inc	20210901	20211217	20220131	20210901	Com	US	A	20220309	20220303 17:02:17		20220303 22:02:17	US	20211130	On Market	Issuer	For Cancellation	USD	154.9300	675100	78949162	92660500	104593271		0.0027	1.9706	1.320000			",
+                         "20220309 11:53:36	BT812996	Transaction	20220309	20191004	US00846U1016	38843345345	27276	Health Care	Health Care	Medical Equipment and Services	Medical Equipment	20102010	Agilent Technologies Inc	20211217	20220222	20220131	20211217	Com	US	A	20220309	20220303 17:02:17		20220303 22:02:17	US	20211231	On Market	Issuer	For Cancellation	USD	154.4500	2038115	232558230	276699052	314786862		0.0081	6.0456	1.350000			"},
+            "20220309",
+            ExpectedResult = "SID,ticker,38843345345,154.4500,154.9300,2713215,419380133,0.0108,8.0162")]
+        public string ProcessUniverseTest(string[] tickerData, string date)
+        {
+            var instance = new SmartInsiderConverter();
+
+            foreach (var line in tickerData)
+            {
+                var smartInsiderTransaction = new SmartInsiderTransaction(line);
+                instance.ProcessUniverse("SID,ticker", smartInsiderTransaction);
+            }
+
+            var result = instance.TransactionUniverse[date].First();
+
+            return $"{result.Key},{result.Value}";
+        }
+        
         [Test]
         public void JsonRoundTrip()
         {

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -29,5 +29,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\QuantConnect.DataSource.csproj" />
+    <ProjectReference Include="..\DataProcessing\DataProcessing.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The previous error is coming from wrong attribute mapping of same-day data aggregation at `ProcessUniverse<SmartInsiderIntention>`. It is now being fixed and sanity-tested against the following sample data with 2 lines of same-day data:
```
20210419 11:04:29	BI14493	Authorisation	20210921	20190817	US41165Y1001		84802	Financials	Banks	Banks	Banks	30101010	HarborOne Bancorp Inc					Ord	US	HONE	20210416					On Market	Issuer	Not Reported	2790903									
20210419 12:53:04	BI15987	Authorisation	20210921	20190817	US41165Y1001		84802	Financials	Banks	Banks	Banks	30101010	HarborOne Bancorp Inc					Ord	US	HONE	20210917				US	On Market	Issuer	Not Reported	2668159					20220917				
```